### PR TITLE
Fixing Uniprot ENSEMBL ID Issue

### DIFF
--- a/secat/main.py
+++ b/secat/main.py
@@ -23,7 +23,7 @@ from pyprophet.data_handling import transform_threads, transform_pi0_lambda
 @click.version_option()
 def cli():
     """
-    SECAT: Size-Exclusion Chromatography Algorithmic Toolkit. test
+    SECAT: Size-Exclusion Chromatography Algorithmic Toolkit.
 
     Visit https://github.com/grosenberger/secat for usage instructions and help.
     """

--- a/secat/preprocess.py
+++ b/secat/preprocess.py
@@ -66,6 +66,9 @@ class uniprot:
             mw = entry.xpath('./uniprot:sequence/@mass', namespaces = self.namespaces)
             ensembl = entry.xpath(ensembl_path, namespaces = self.namespaces)
 
+            # To keep Ensembl IDs backwards compatible, ignore the version specifier
+            ensembl = [e.split(".")[0] for e in ensembl]
+
             row = pd.Series({
                 'protein_id': _extract(accession), 
                 'protein_name': _extract(name), 
@@ -77,6 +80,7 @@ class uniprot:
         
         # Append each Series object as a new row to df
         df = pd.concat([df, *[row.to_frame().T for row in rows]], ignore_index=True)
+
         return df
 
     def to_df(self):


### PR DESCRIPTION
Newer Uniprot versions include the version specifier in the ENSEMBL IDs. However, not all other databases use this version specifier (e.g. STRING) which leads to unwanted behavior. This behavior cascades to all steps since it happens in `secat/preprocess.py`. To fix this, I've changed the `uniprot` class in `secat/preprocess.py` to strip the version specifier if it exists. If there is no version specifier the code returns the same ids as usual. 

The erroneous behavior can be verified with the human uniprot version as of 08/03/2023. Presumably this is a permanent change, but users maybe want to use older Uniprot files (hence the backwards compatibility).